### PR TITLE
Making CRDs helm3 compatible

### DIFF
--- a/manifests/charts/istio-operator/crds/crd-operator.yaml
+++ b/manifests/charts/istio-operator/crds/crd-operator.yaml
@@ -44,3 +44,49 @@ spec:
     served: true
     storage: true
 ---
+# SYNC WITH manifests/charts/base/files
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: istiooperators.install.istio.io
+spec:
+  group: install.istio.io
+  names:
+    kind: IstioOperator
+    plural: istiooperators
+    singular: istiooperator
+    shortNames:
+    - iop
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values.
+            More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase.
+            More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        spec:
+          description: 'Specification of the desired state of the istio control plane resource.
+            More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+          type: object
+        status:
+          description: 'Status describes each of istio control plane component status at the current time.
+            0 means NONE, 1 means UPDATING, 2 means HEALTHY, 3 means ERROR, 4 means RECONCILING.
+            More info: https://github.com/istio/api/blob/master/operator/v1alpha1/istio.operator.v1alpha1.pb.html &
+            https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+          type: object
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+---

--- a/manifests/charts/istio-operator/templates/crd.yaml
+++ b/manifests/charts/istio-operator/templates/crd.yaml
@@ -1,0 +1,6 @@
+{{- if .Values.createCRD -}}
+{{- range $path, $bytes := .Files.Glob "crds/*.yaml" -}}
+---
+{{ $.Files.Get $path }}
+{{- end -}}
+{{- end -}}

--- a/manifests/charts/istio-operator/values.yaml
+++ b/manifests/charts/istio-operator/values.yaml
@@ -3,3 +3,4 @@ tag: 1.6-dev
 operatorNamespace: istio-operator
 istioNamespace: istio-system
 waitForResourcesTimeout: 300s
+createCRD: false


### PR DESCRIPTION
This ensures CRDs are created using the [helm3 approach](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/#method-1-let-helm-do-it-for-you). 

If the helm release for the istio-operator is deleted, a re-install will always fail with the current chart due to CRDs.